### PR TITLE
Master

### DIFF
--- a/transcriber.js
+++ b/transcriber.js
@@ -380,7 +380,7 @@ TS.retrieveText = function () {
  */
 TS.clearStorage = function () {
 	if (localStorage) {
-		localStorage.clear();
+		localStorage.removeItem('transcript');
 		TS.transcriptTextarea.value = "";
 
 		TS.createCookie('infoAreaOpen', "", -1); // sets expiry data to past


### PR DESCRIPTION
No longer uses clear all function, but just removes the one key in use.
Other pages on the same domain are thus not affected by this clear
storage function.